### PR TITLE
Update plugin.php

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: Vuefront
  * Plugin URI: https://github.com/vuefront/wordpress
  * Description: VueFront CMS Connect App for Wordpress.
- * Version: 1.0
+ * Version: 1.1.0
  * Author: Dreamvention
  * Author URI: http://dreamvention.com
  */


### PR DESCRIPTION
LOW LEVEL priority:

You should also keep sync versions in plugin.php [from readme.txt](https://github.com/vuefront/wordpress/blob/master/readme.txt#L8)
or I won't see right version in wp plugin's panel.